### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ function KeyPath(obj) {
 		let ret = obj;
 
 		for (let idx = 0 ; idx < keyPath.length - 1 ; idx++) {
+      if (ret[keyPath[idx]] === Object.prototype) continue;
 			ret = ret[keyPath[idx]] = ret[keyPath[idx]] || {};
 		}
 

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function KeyPath(obj) {
 		let ret = obj;
 
 		for (let idx = 0 ; idx < keyPath.length - 1 ; idx++) {
-      if (ret[keyPath[idx]] === Object.prototype) continue;
+			if (ret[keyPath[idx]] === Object.prototype) continue;
 			ret = ret[keyPath[idx]] = ret[keyPath[idx]] || {};
 		}
 

--- a/test/index.js
+++ b/test/index.js
@@ -32,6 +32,11 @@ const test = (options) => {
 	it ('should modify original object', () => {
 		expect(obj.this.is.a.new.value).to.equal(true);
 	});
+
+	it ('should not allow protopath overwrite', () => {
+		expect(keyPath(obj).set('__proto__.polluted', true).polluted).to.be.equal(undefined);
+		expect(keyPath(obj).set('constructor.prototype.polluted', true).polluted).to.be.equal(undefined);
+	})
 	
 	it ('should come back with all items', () => {
 		expect(keyPath(arr).getAll(convert('this.is.a.value'), merge(true, options))).to.deep.equal([1,2,3,4]);


### PR DESCRIPTION
@d3v53c (https://huntr.dev/users/d3v53c) has fixed a potential Prototype Pollution vulnerability in your repository 🔨. For more information, visit our website (https://huntr.dev/) or click the bounty URL below...

Q | A
Version Affected | *
Bug Fix | YES
Original Pull Request | https://github.com/418sec/keyd/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/keyd/1/README.md

### User Comments:

### 📊 Metadata *

`keyd `is vulnerable to Prototype Pollution. This package fails to restrict access to prototypes of objects, allowing for modification of prototype behavior using a proto payload, which may result in Sensitive Information Disclosure/Denial of Service(DoS)/Remote Code Execution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-keyd/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns unmodified object, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```
// poc.js
var keyd = require("keyd")
var obj = {}
console.log("Before : " + {}.polluted);
keyd(obj).set('__proto__.polluted', 'Yes! Its Polluted');
console.log("After : " + {}.polluted);
```

2. Execute the following commands in another terminal:

```
npm i keyd # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:

```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/107872991-b85a9b80-6ed4-11eb-9f88-245e9d22d808.png)

After:
![image](https://user-images.githubusercontent.com/64132745/107872970-86e1d000-6ed4-11eb-8744-cda911188384.png)

### 👍 User Acceptance Testing (UAT)

After the fix, functionality is unaffected.
![image](https://user-images.githubusercontent.com/64132745/107873610-c65eeb00-6ed9-11eb-914f-d308c398df90.png)

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1899
